### PR TITLE
an editorconfig file and a gitignore file.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+#top-most editorconfig file
+root = true
+
+#2 space indentation
+#some files use 3 space indentation, but I can't find a pattern.
+[*]
+end_of_line = crlf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json


### PR DESCRIPTION
gitignore file ignores the node_modules directories and the package-lock.json files.

editorconfig makes editing the files with control-linefeeds and 2-space indentation easier.